### PR TITLE
Release v2.3.1-beta: Death Detection and XP Exploit Fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ Desktop.ini
 
 # Log files
 *.log
+serverlogs/
 
 # Temporary files
 tmp/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,35 @@
 
 All notable changes to Living Lands will be documented in this file.
 
+## [2.3.1-beta] - 2026-01-20
+
+### Fixed
+
+#### Death Detection
+- **Metabolism Reset on Death** - Fixed metabolism not resetting when players die and respawn
+- **ECS-Based Detection** - Now uses `KillFeedEvent.DecedentMessage` ECS system to reset metabolism immediately on death rather than waiting for respawn event
+
+#### Mining/Logging XP Exploit
+- **Player-Placed Block Detection** - Fixed exploit where players could gain XP by breaking blocks they placed themselves
+- **Empty Block Event Handling** - Fixed issue where `BreakBlockEvent` with `block=Empty` (fires when placing blocks) was corrupting block tracking
+- **Correct Hytale Block IDs** - Updated to use actual Hytale block naming conventions:
+  - Ores: `Ore_Copper`, `Ore_Iron`, `Ore_Gold`, etc. (prefix matching)
+  - Rocks: `Rock_Stone`, `Rock_Basalt`, `Rock_Sandstone`, etc. (exact matching)
+  - Wood: `Wood_*` prefix (e.g., `Wood_Oak_Trunk`, `Wood_Birch_Roots`)
+  - Leaves: `Plant_Leaves_*` prefix (e.g., `Plant_Leaves_Oak`)
+
+#### Player-Placed Block Persistence
+- **Cross-Restart Tracking** - Player-placed blocks are now tracked persistently across server restarts
+- **Per-World Storage** - Placed block positions stored per-world in `LivingLands/leveling/placed_blocks/`
+
+### Technical Details
+- New `PlayerDeathSystem` ECS system listens to `KillFeedEvent.DecedentMessage`
+- `MiningXpSystem` and `LoggingXpSystem` skip events where `blockId == "Empty"`
+- Block ID matching uses prefix patterns for ores/wood/leaves and exact matches for stone blocks
+- `PlacedBlockPersistence` saves/loads placed block positions per world
+
+---
+
 ## [2.3.0-beta] - 2026-01-19
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -518,7 +518,7 @@ The metabolism module is optimized for **O(n) linear scaling** with player count
 # Credits
 
 - **Author**: [MoshPitCodes](https://github.com/MoshPitCodes)
-- **Version**: 2.3.0-beta
+- **Version**: 2.3.1-beta
 - **License**: Apache-2.0
 
 ### Resources

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 group = "com.livinglands"
-version = "2.3.0-beta"
+version = "2.3.1-beta"
 
 repositories {
     mavenCentral()

--- a/docs/MODPAGE.md
+++ b/docs/MODPAGE.md
@@ -2,7 +2,7 @@
 
 **Living Lands** transforms Hytale into an immersive survival experience. Manage your character's **hunger**, **thirst**, and **energy** while exploring the world. The mod integrates seamlessly with vanilla items - no new blocks or complicated recipes, just pure survival gameplay.
 
-**Version 2.3.0** features an **enhanced HUD** with real-time buff/debuff indicators, a **buff/debuff system** that rewards well-maintained stats and penalizes neglect, plus a **modular architecture** - enable only the features you want!
+**Version 2.3.1** features an **enhanced HUD** with real-time buff/debuff indicators, a **buff/debuff system** that rewards well-maintained stats and penalizes neglect, plus a **modular architecture** - enable only the features you want!
 
 ---
 

--- a/docs/MODPAGE_CHANGELOG.md
+++ b/docs/MODPAGE_CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to Living Lands for players and server administrators.
 
 ---
 
+## Version 2.3.1-beta - January 2026
+
+### Fixed
+
+#### Death Detection
+- **Metabolism Reset on Death** - Fixed metabolism not resetting when players die and respawn
+- Metabolism stats now properly reset to initial values immediately when you die
+
+#### Mining/Logging XP Exploit
+- **Player-Placed Block Detection** - Fixed exploit where players could gain XP by breaking blocks they placed themselves
+- Breaking player-placed ores, rocks, wood, or leaves no longer awards XP
+- Only naturally-generated blocks award XP
+
+#### Player-Placed Block Tracking
+- **Persistent Tracking** - Player-placed blocks are now tracked across server restarts
+- Your placed blocks will still be tracked after the server reboots
+
+---
+
 ## Version 2.3.0-beta - January 2026
 
 ### New Features

--- a/docs/TECHNICAL_DESIGN.md
+++ b/docs/TECHNICAL_DESIGN.md
@@ -697,3 +697,4 @@ public record DebuffsConfig(
 | 2.2.0-beta | Speed modification client sync, performance optimization |
 | 2.2.1-beta | Stamina debuff implementation |
 | 2.3.0-beta | Enhanced HUD, passive abilities panel, leveling integration |
+| 2.3.1-beta | Death detection fix, mining/logging XP exploit fix, block persistence |

--- a/src/main/java/com/livinglands/modules/leveling/LevelingModule.java
+++ b/src/main/java/com/livinglands/modules/leveling/LevelingModule.java
@@ -27,7 +27,7 @@ public final class LevelingModule extends AbstractModule {
 
     public static final String ID = "leveling";
     public static final String NAME = "Leveling System";
-    public static final String VERSION = "1.0.0";
+    public static final String VERSION = "1.0.1";
 
     private LevelingModuleConfig config;
     private LevelingSystem system;

--- a/src/main/java/com/livinglands/modules/metabolism/MetabolismModule.java
+++ b/src/main/java/com/livinglands/modules/metabolism/MetabolismModule.java
@@ -32,7 +32,7 @@ public final class MetabolismModule extends AbstractModule {
 
     public static final String ID = "metabolism";
     public static final String NAME = "Metabolism System";
-    public static final String VERSION = "1.1.0";
+    public static final String VERSION = "1.1.1";
 
     private MetabolismModuleConfig config;
     private MetabolismSystem system;


### PR DESCRIPTION
## Summary

- **Fix metabolism reset on death** - Metabolism now resets immediately when players die, rather than waiting for respawn events that weren't firing
- **Fix mining/logging XP exploit** - Players can no longer gain XP by breaking blocks they placed themselves
- **Fix Empty block event handling** - Prevents block tracking corruption when placing blocks
- **Update Hytale block IDs** - Use correct naming conventions (Ore_*, Rock_*, Wood_*, Plant_Leaves_*)
- **Add placed block persistence** - Player-placed blocks tracked across server restarts

## Test plan

- [ ] Verify metabolism resets to initial values when a player dies
- [ ] Verify breaking player-placed ores does not award mining XP
- [ ] Verify breaking player-placed wood does not award logging XP
- [ ] Verify naturally-generated blocks still award XP
- [ ] Verify block tracking persists after server restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)