### PR TITLE
Release v2.3.2-beta: Speed Flickering Fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to Living Lands will be documented in this file.
 
+## [2.3.2-beta] - 2026-01-20
+
+### Fixed
+
+#### Speed Modification Flickering
+- **Centralized Speed Management** - Fixed speed flickering caused by race condition between buff and debuff systems
+- **SpeedManager** - New centralized component that tracks original speed and combines all multipliers before applying
+- **Single Update Per Tick** - Speed is now applied once after both systems process, eliminating conflicting updates
+
+### Technical Details
+- New `SpeedManager` class handles all speed modifications centrally
+- `DebuffsSystem` and `BuffsSystem` now set multipliers via SpeedManager instead of directly modifying baseSpeed
+- Combined multiplier calculated as: `energyDebuff * thirstDebuff * buff` (debuffs take priority over buffs)
+- Original base speed captured only once on first modification, ensuring correct restoration
+
+---
+
 ## [2.3.1-beta] - 2026-01-20
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -518,7 +518,7 @@ The metabolism module is optimized for **O(n) linear scaling** with player count
 # Credits
 
 - **Author**: [MoshPitCodes](https://github.com/MoshPitCodes)
-- **Version**: 2.3.1-beta
+- **Version**: 2.3.2-beta
 - **License**: Apache-2.0
 
 ### Resources

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
 }
 
 group = "com.livinglands"
-version = "2.3.1-beta"
+version = "2.3.2-beta"
 
 repositories {
     mavenCentral()

--- a/docs/MODPAGE.md
+++ b/docs/MODPAGE.md
@@ -2,7 +2,7 @@
 
 **Living Lands** transforms Hytale into an immersive survival experience. Manage your character's **hunger**, **thirst**, and **energy** while exploring the world. The mod integrates seamlessly with vanilla items - no new blocks or complicated recipes, just pure survival gameplay.
 
-**Version 2.3.1** features an **enhanced HUD** with real-time buff/debuff indicators, a **buff/debuff system** that rewards well-maintained stats and penalizes neglect, plus a **modular architecture** - enable only the features you want!
+**Version 2.3.2** features an **enhanced HUD** with real-time buff/debuff indicators, a **buff/debuff system** that rewards well-maintained stats and penalizes neglect, plus a **modular architecture** - enable only the features you want!
 
 ---
 

--- a/docs/MODPAGE_CHANGELOG.md
+++ b/docs/MODPAGE_CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to Living Lands for players and server administrators.
 
 ---
 
+## Version 2.3.2-beta - January 2026
+
+### Fixed
+
+#### Speed Flickering
+- **Fixed Speed Flickering** - Movement speed no longer flickers when buffs and debuffs are active
+- The speed system now uses centralized management to prevent conflicts
+
+---
+
 ## Version 2.3.1-beta - January 2026
 
 ### Fixed

--- a/docs/TECHNICAL_DESIGN.md
+++ b/docs/TECHNICAL_DESIGN.md
@@ -698,3 +698,4 @@ public record DebuffsConfig(
 | 2.2.1-beta | Stamina debuff implementation |
 | 2.3.0-beta | Enhanced HUD, passive abilities panel, leveling integration |
 | 2.3.1-beta | Death detection fix, mining/logging XP exploit fix, block persistence |
+| 2.3.2-beta | Speed flickering fix via centralized SpeedManager |

--- a/src/main/java/com/livinglands/modules/metabolism/MetabolismModule.java
+++ b/src/main/java/com/livinglands/modules/metabolism/MetabolismModule.java
@@ -32,7 +32,7 @@ public final class MetabolismModule extends AbstractModule {
 
     public static final String ID = "metabolism";
     public static final String NAME = "Metabolism System";
-    public static final String VERSION = "1.1.1";
+    public static final String VERSION = "1.1.2";
 
     private MetabolismModuleConfig config;
     private MetabolismSystem system;

--- a/src/main/java/com/livinglands/modules/metabolism/SpeedManager.java
+++ b/src/main/java/com/livinglands/modules/metabolism/SpeedManager.java
@@ -1,0 +1,268 @@
+package com.livinglands.modules.metabolism;
+
+import com.hypixel.hytale.component.Ref;
+import com.hypixel.hytale.component.Store;
+import com.hypixel.hytale.logger.HytaleLogger;
+import com.hypixel.hytale.server.core.entity.entities.player.movement.MovementManager;
+import com.hypixel.hytale.server.core.universe.PlayerRef;
+import com.hypixel.hytale.server.core.universe.world.World;
+import com.hypixel.hytale.server.core.universe.world.storage.EntityStore;
+
+import javax.annotation.Nonnull;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.logging.Level;
+
+/**
+ * Centralized manager for player movement speed modifications.
+ *
+ * This class solves the race condition where multiple systems (DebuffsSystem, BuffsSystem)
+ * were independently modifying baseSpeed, causing flickering speed changes.
+ *
+ * Now all speed modifiers are tracked here and combined into a single multiplier
+ * that is applied once per tick.
+ */
+public class SpeedManager {
+
+    private final HytaleLogger logger;
+
+    // Track the true original base speed for each player (captured on first modification)
+    private final Map<UUID, Float> originalBaseSpeeds = new ConcurrentHashMap<>();
+
+    // Track current multipliers from different sources
+    private final Map<UUID, Float> energyDebuffMultipliers = new ConcurrentHashMap<>();
+    private final Map<UUID, Float> thirstDebuffMultipliers = new ConcurrentHashMap<>();
+    private final Map<UUID, Float> buffMultipliers = new ConcurrentHashMap<>();
+
+    // Track last applied combined multiplier to avoid redundant updates
+    private final Map<UUID, Float> lastAppliedMultipliers = new ConcurrentHashMap<>();
+
+    public SpeedManager(@Nonnull HytaleLogger logger) {
+        this.logger = logger;
+    }
+
+    /**
+     * Sets the energy debuff speed multiplier for a player.
+     *
+     * @param playerId The player's UUID
+     * @param multiplier The multiplier (1.0 = no change, 0.6 = 60% speed)
+     */
+    public void setEnergyDebuffMultiplier(UUID playerId, float multiplier) {
+        if (multiplier >= 1.0f) {
+            energyDebuffMultipliers.remove(playerId);
+        } else {
+            energyDebuffMultipliers.put(playerId, multiplier);
+        }
+    }
+
+    /**
+     * Sets the thirst debuff speed multiplier for a player.
+     *
+     * @param playerId The player's UUID
+     * @param multiplier The multiplier (1.0 = no change, 0.45 = 45% speed)
+     */
+    public void setThirstDebuffMultiplier(UUID playerId, float multiplier) {
+        if (multiplier >= 1.0f) {
+            thirstDebuffMultipliers.remove(playerId);
+        } else {
+            thirstDebuffMultipliers.put(playerId, multiplier);
+        }
+    }
+
+    /**
+     * Sets the buff speed multiplier for a player.
+     *
+     * @param playerId The player's UUID
+     * @param multiplier The multiplier (1.0 = no change, 1.2 = 120% speed)
+     */
+    public void setBuffMultiplier(UUID playerId, float multiplier) {
+        if (multiplier <= 1.0f) {
+            buffMultipliers.remove(playerId);
+        } else {
+            buffMultipliers.put(playerId, multiplier);
+        }
+    }
+
+    /**
+     * Clears all speed modifiers for a player.
+     * Called when buffs are suppressed by debuffs.
+     */
+    public void clearBuffMultiplier(UUID playerId) {
+        buffMultipliers.remove(playerId);
+    }
+
+    /**
+     * Clears the energy debuff multiplier for a player.
+     */
+    public void clearEnergyDebuffMultiplier(UUID playerId) {
+        energyDebuffMultipliers.remove(playerId);
+    }
+
+    /**
+     * Clears the thirst debuff multiplier for a player.
+     */
+    public void clearThirstDebuffMultiplier(UUID playerId) {
+        thirstDebuffMultipliers.remove(playerId);
+    }
+
+    /**
+     * Calculates the combined speed multiplier for a player.
+     * Debuffs and buffs are multiplicative.
+     *
+     * @param playerId The player's UUID
+     * @return The combined multiplier
+     */
+    public float getCombinedMultiplier(UUID playerId) {
+        float multiplier = 1.0f;
+
+        // Apply debuffs (reduce speed)
+        Float energyMult = energyDebuffMultipliers.get(playerId);
+        if (energyMult != null) {
+            multiplier *= energyMult;
+        }
+
+        Float thirstMult = thirstDebuffMultipliers.get(playerId);
+        if (thirstMult != null) {
+            multiplier *= thirstMult;
+        }
+
+        // Apply buffs (increase speed) - only if no debuffs are reducing speed
+        Float buffMult = buffMultipliers.get(playerId);
+        if (buffMult != null && multiplier >= 1.0f) {
+            multiplier *= buffMult;
+        }
+
+        return multiplier;
+    }
+
+    /**
+     * Checks if a player has any active speed modifiers.
+     */
+    public boolean hasActiveModifiers(UUID playerId) {
+        return energyDebuffMultipliers.containsKey(playerId) ||
+               thirstDebuffMultipliers.containsKey(playerId) ||
+               buffMultipliers.containsKey(playerId);
+    }
+
+    /**
+     * Applies the combined speed modifier to the player.
+     * Should be called once per tick after all systems have set their multipliers.
+     *
+     * @param playerId The player's UUID
+     * @param ref The entity reference
+     * @param store The entity store
+     * @param world The world for thread-safe execution
+     */
+    public void applySpeedModifier(UUID playerId, Ref<EntityStore> ref, Store<EntityStore> store, World world) {
+        float combinedMultiplier = getCombinedMultiplier(playerId);
+
+        // Check if multiplier changed significantly (avoid spamming updates)
+        Float lastApplied = lastAppliedMultipliers.get(playerId);
+        if (lastApplied != null && Math.abs(lastApplied - combinedMultiplier) < 0.01f) {
+            return; // No significant change, skip update
+        }
+
+        world.execute(() -> {
+            try {
+                var movementManager = store.getComponent(ref, MovementManager.getComponentType());
+                if (movementManager == null) {
+                    return;
+                }
+
+                var settings = movementManager.getSettings();
+                if (settings == null) {
+                    return;
+                }
+
+                // Store original base speed if not already stored
+                if (!originalBaseSpeeds.containsKey(playerId)) {
+                    originalBaseSpeeds.put(playerId, settings.baseSpeed);
+                    logger.at(Level.FINE).log("SpeedManager: Stored original base speed for player %s: %.2f",
+                        playerId, settings.baseSpeed);
+                }
+
+                float originalSpeed = originalBaseSpeeds.get(playerId);
+                float newSpeed = originalSpeed * combinedMultiplier;
+
+                // Apply the modified speed
+                settings.baseSpeed = newSpeed;
+                lastAppliedMultipliers.put(playerId, combinedMultiplier);
+
+                // Sync the movement settings to the client
+                var playerRef = store.getComponent(ref, PlayerRef.getComponentType());
+                if (playerRef != null) {
+                    movementManager.update(playerRef.getPacketHandler());
+                }
+
+                logger.at(Level.FINE).log("SpeedManager: Applied speed to player %s: %.2f -> %.2f (%.0f%% combined)",
+                    playerId, originalSpeed, newSpeed, combinedMultiplier * 100);
+
+            } catch (Exception e) {
+                logger.at(Level.WARNING).withCause(e).log("SpeedManager: Error applying speed modifier for player %s", playerId);
+            }
+        });
+    }
+
+    /**
+     * Restores original speed for a player if no modifiers are active.
+     *
+     * @param playerId The player's UUID
+     * @param ref The entity reference
+     * @param store The entity store
+     * @param world The world for thread-safe execution
+     */
+    public void restoreOriginalSpeedIfNoModifiers(UUID playerId, Ref<EntityStore> ref, Store<EntityStore> store, World world) {
+        if (hasActiveModifiers(playerId)) {
+            return; // Still have modifiers, don't restore
+        }
+
+        if (!originalBaseSpeeds.containsKey(playerId)) {
+            return; // No original speed stored
+        }
+
+        world.execute(() -> {
+            try {
+                var movementManager = store.getComponent(ref, MovementManager.getComponentType());
+                if (movementManager == null) {
+                    return;
+                }
+
+                var settings = movementManager.getSettings();
+                if (settings == null) {
+                    return;
+                }
+
+                float originalSpeed = originalBaseSpeeds.get(playerId);
+                settings.baseSpeed = originalSpeed;
+
+                // Clean up tracking
+                originalBaseSpeeds.remove(playerId);
+                lastAppliedMultipliers.remove(playerId);
+
+                // Sync the movement settings to the client
+                var playerRef = store.getComponent(ref, PlayerRef.getComponentType());
+                if (playerRef != null) {
+                    movementManager.update(playerRef.getPacketHandler());
+                }
+
+                logger.at(Level.INFO).log("SpeedManager: Restored original speed for player %s: %.2f",
+                    playerId, originalSpeed);
+
+            } catch (Exception e) {
+                logger.at(Level.WARNING).withCause(e).log("SpeedManager: Error restoring speed for player %s", playerId);
+            }
+        });
+    }
+
+    /**
+     * Cleans up all tracking data for a player (on disconnect).
+     */
+    public void removePlayer(UUID playerId) {
+        originalBaseSpeeds.remove(playerId);
+        energyDebuffMultipliers.remove(playerId);
+        thirstDebuffMultipliers.remove(playerId);
+        buffMultipliers.remove(playerId);
+        lastAppliedMultipliers.remove(playerId);
+    }
+}


### PR DESCRIPTION
## Summary

- **Fix speed flickering** - Movement speed no longer flickers when buffs and debuffs are active simultaneously
- **Centralized SpeedManager** - New component that handles all speed modifications to prevent race conditions
- **Single update per tick** - Speed is now applied once after both buff and debuff systems process

## Root Cause

Both `DebuffsSystem` and `BuffsSystem` were independently modifying `settings.baseSpeed` with their own tracking maps. This caused:
1. Each system stored potentially wrong "original" speed values
2. Both systems called `movementManager.update()` repeatedly
3. Speed flickered as systems competed to set different values

## Solution

Created `SpeedManager` that:
- Tracks the **true** original base speed (captured only once)
- Maintains separate multipliers for energy debuffs, thirst debuffs, and buffs
- Calculates combined multiplier: `energyDebuff * thirstDebuff * buff`
- Applies speed once per tick with single `movementManager.update()` call

## Files Changed

- **New**: `src/main/java/com/livinglands/modules/metabolism/SpeedManager.java`
- **Modified**: `DebuffsSystem.java` - Uses SpeedManager instead of direct speed manipulation
- **Modified**: `BuffsSystem.java` - Uses SpeedManager instead of direct speed manipulation
- **Modified**: `MetabolismSystem.java` - Creates and wires SpeedManager, applies speed after processing

## Test plan

- [ ] Verify speed remains stable when energy/thirst debuffs are active
- [ ] Verify speed buff activates correctly at high energy
- [ ] Verify no flickering when transitioning between buff and debuff states
- [ ] Verify speed restores to original when all modifiers are removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)